### PR TITLE
webapi: Improve logs on lights connection issues

### DIFF
--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -8,9 +8,9 @@ use std::{
 
 use async_trait::async_trait;
 use lightfx::{Color, Frame};
-use log::error;
+use log::debug;
 #[cfg(feature = "visualiser")]
-use log::info;
+use log::{error, info};
 use reqwest::header::CONNECTION;
 
 #[derive(Debug)]
@@ -70,6 +70,7 @@ impl RemoteLightClient {
             http_client: reqwest::Client::builder()
                 .http1_title_case_headers()
                 .tcp_keepalive(Duration::from_secs(10))
+                .timeout(Duration::from_secs(1))
                 .build()
                 .unwrap(),
         }
@@ -95,7 +96,7 @@ impl LightClient for RemoteLightClient {
         {
             Ok(_) => Ok(()),
             Err(err) => {
-                error!("Failed to send a frame to remote lights client: {}", err);
+                debug!("Failed to send frame to light client: {}", err);
                 Err(LightClientError::ConnectionLost)
             }
         }


### PR DESCRIPTION
Example logs before change:

```log
23:15:25 [INFO] Trying to switch animation to "blank"
23:32:36 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:32:36 [WARN] Lost connection to light client, will retry in 0.06666666666666667 seconds
23:32:44 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:32:44 [WARN] Lost connection to light client, will retry in 0.13333333333333333 seconds
23:32:53 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:32:53 [WARN] Lost connection to light client, will retry in 0.26666666666666666 seconds
23:33:02 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:33:02 [WARN] Lost connection to light client, will retry in 0.5333333333333333 seconds
23:33:11 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:33:11 [WARN] Lost connection to light client, will retry in 1.0666666666666667 seconds
23:33:20 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:33:20 [WARN] Lost connection to light client, will retry in 2.1333333333333333 seconds
23:33:31 [ERROR] Failed to send a frame to remote lights client: error sending request for url (http://192.168.0.25/pixels): connection closed before message completed
23:33:31 [WARN] Lost connection to light client, will retry in 4.266666666666667 seconds
23:34:06 [INFO] SIGINT received; starting forced shutdown
```

After changes:

```log
00:00:26 [INFO] Trying to switch animation to "rainbow_waterfall"
00:00:37 [WARN] Failed to send frame to remote lights, will retry in 0.07 seconds
00:00:38 [WARN] Failed to send frame to remote lights, will retry in 0.13 seconds
00:00:40 [WARN] Failed to send frame to remote lights, will retry in 0.27 seconds
00:00:41 [WARN] Failed to send frame to remote lights, will retry in 0.53 seconds
00:00:42 [WARN] Failed to send frame to remote lights, will retry in 1.07 seconds
00:00:44 [WARN] Failed to send frame to remote lights, will retry in 2.13 seconds
00:00:48 [WARN] Failed to send frame to remote lights, will retry in 4.27 seconds
00:00:53 [WARN] Lost connection to lights, will continue retrying every 5.00 seconds
00:01:28 [INFO] Regained connection to light client
00:01:49 [INFO] Trying to switch animation to "blank"
```