### PR TITLE
webui: Fix select element handling

### DIFF
--- a/webui/Cargo.toml
+++ b/webui/Cargo.toml
@@ -13,5 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3.60", features = ["FormData", "HtmlFormElement"] }
+web-sys = { version = "0.3.60", features = ["FormData", "HtmlFormElement", "HtmlSelectElement"] }
 yew = "0.19"

--- a/webui/src/controls/mod.rs
+++ b/webui/src/controls/mod.rs
@@ -11,7 +11,8 @@ use lightfx::{
 };
 use wasm_bindgen::JsCast;
 use web_sys::{
-    Event, EventTarget, FocusEvent, FormData, HtmlFormElement, HtmlInputElement, InputEvent,
+    Event, EventTarget, FocusEvent, FormData, HtmlFormElement, HtmlInputElement, HtmlSelectElement,
+    InputEvent,
 };
 use yew::{html, Callback, Component, Context, Html, Properties};
 
@@ -24,8 +25,12 @@ use self::debouncer::Debouncer;
 
 fn get_form(target: Option<EventTarget>) -> Option<HtmlFormElement> {
     target
-        .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+        .clone()
+        .and_then(|t| t.dyn_into::<HtmlSelectElement>().ok())
         .and_then(|e| e.form())
+        .or(target
+            .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+            .and_then(|e| e.form()))
 }
 
 #[derive(Properties, PartialEq, Clone)]

--- a/webui/src/controls/select_control.rs
+++ b/webui/src/controls/select_control.rs
@@ -1,5 +1,5 @@
 use lightfx::parameter_schema::{Parameter, ParameterValue};
-use serde_json::json;
+use web_sys::HtmlSelectElement;
 use yew::{html, Component, Context, Html, NodeRef};
 
 use super::ParameterControlProps;
@@ -24,22 +24,38 @@ impl Component for SelectParameterControl {
             ..
         } = ctx.props().schema.clone()
         {
-            let selected_value = serde_json::to_string(ctx.props().value.as_ref().unwrap_or(
-                &json!(values.first().map(|v| v.name.clone()).unwrap_or_default()),
-            ))
-            .unwrap();
+            let selected_index = ctx
+                .props()
+                .value
+                .as_ref()
+                .and_then(|v| v.as_str())
+                .and_then(|v| values.iter().position(|opt| opt.value == v))
+                .unwrap_or(0);
+
             html! {
-                <select name={id} ref={self.node_ref.clone()}>
+                <select name={id} ref={self.node_ref.clone()} data-selected-index={selected_index.to_string()}>
                     {values.into_iter().map(|item| {
                         let value = format!("\"{}\"", item.value);
-                        let selected = value == selected_value;
                         html!(
-                        <option {selected} {value}><strong>{item.name}</strong> {item.description.unwrap_or_default()}</option>
+                        <option {value}><strong>{item.name}</strong> {item.description.unwrap_or_default()}</option>
                     )}).collect::<Html>()}
                 </select>
             }
         } else {
             html!()
         }
+    }
+
+    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
+        self.node_ref
+            .cast::<HtmlSelectElement>()
+            .and_then(|elem| elem.get_attribute("data-selected-index"))
+            .and_then(|attr| attr.parse::<i32>().ok())
+            .and_then(|index| {
+                self.node_ref.cast::<HtmlSelectElement>().and_then(|elem| {
+                    elem.set_selected_index(index);
+                    Some(())
+                })
+            });
     }
 }


### PR DESCRIPTION
* onchange event on the form incorrectly assumed that the target element will be HtmlInputElement, while it could also be HtmlSelectElement; not it will try both
* select was not correctly updated on reset; apparently the right way to do it is with `set_selected_index`