### PR TITLE
animator: Fix Barber Pole on negative time values

### DIFF
--- a/animator/src/animations/barber_pole.rs
+++ b/animator/src/animations/barber_pole.rs
@@ -42,7 +42,7 @@ impl Animation for BarberPole {
         self.points_polar
             .iter()
             .map(|(_, a, h)| {
-                if (a / PI + time + h * self.parameters.density) % 2.0 < 1.0 {
+                if utils::cycle(a / PI + time + h * self.parameters.density, 2.0) < 1.0 {
                     self.parameters.color_a
                 } else {
                     self.parameters.color_b

--- a/animator/src/animations/utils.rs
+++ b/animator/src/animations/utils.rs
@@ -22,3 +22,11 @@ pub fn random_rotation() -> Rotation3<f64> {
 pub fn random_hue(saturation: f64, value: f64) -> lightfx::Color {
     lightfx::Color::hsv(rand::thread_rng().gen::<f64>() % 1.0, saturation, value)
 }
+
+pub fn cycle(value: f64, cycle_length: f64) -> f64 {
+    if value > 0.0 {
+        value % cycle_length
+    } else {
+        cycle_length + value % cycle_length
+    }
+}


### PR DESCRIPTION
After adding time-reversible control, animations could go into negative time values. Barber Pole animation was not ready to handle negative time due to usage of modulo arithmetic on time parameter.

Other animations are not affected, because they either don't do modulo division on time, or they use HSV calculations, which already include the same fix that was added to Barber Pole in this commit.