### PR TITLE
Fix formatting and clippy errors on updated toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
         id: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.72.0
           profile: minimal
           components: rustfmt
       - name: Check formatting

--- a/animator/src/lib.rs
+++ b/animator/src/lib.rs
@@ -111,7 +111,8 @@ impl Controller {
                 let delta = now - state.last_frame;
                 state.last_frame = now;
                 if let Some(ref mut animation) = state.animation {
-                    animation.update(delta.num_milliseconds() as f64 / 1000.0)
+                    animation
+                        .update(delta.num_milliseconds() as f64 / 1000.0)
                         .and_then(|_| animation.render())
                 } else {
                     Ok(lightfx::Frame::new_black(point_count))
@@ -181,8 +182,8 @@ impl Controller {
             .animation
             .as_ref()
             .map(AnimationPlugin::animation_name)
-            .transpose()? else
-        {
+            .transpose()?
+        else {
             return Ok(());
         };
 

--- a/bevy-visualizer/src/websocket.rs
+++ b/bevy-visualizer/src/websocket.rs
@@ -34,7 +34,9 @@ pub(crate) fn listen_for_frame(
             ev.pixels.len()
         );
         for (material, led) in query.iter() {
-            let Some(color) = ev.pixels.get(led.0) else { continue; };
+            let Some(color) = ev.pixels.get(led.0) else {
+                continue;
+            };
             materials.get_mut(material).unwrap().base_color =
                 bevy::prelude::Color::rgb_u8(color.r, color.g, color.b);
         }

--- a/configurator/src/capture.rs
+++ b/configurator/src/capture.rs
@@ -242,8 +242,8 @@ impl Capturer {
 
         [WithConfidence::default()]
             .into_iter()
-            .chain(raw_points.into_iter())
-            .chain([WithConfidence::default()].into_iter())
+            .chain(raw_points)
+            .chain([WithConfidence::default()])
             .tuple_windows()
             .map(|(before, current, after)| {
                 if before.confident()
@@ -360,8 +360,8 @@ impl Capturer {
     ) -> Vec<WithConfidence<Vector3<f64>>> {
         front
             .into_iter()
-            .zip(back.into_iter())
-            .zip(left.into_iter().zip(right.into_iter()))
+            .zip(back)
+            .zip(left.into_iter().zip(right))
             .map(|((front, back), (left, right))| Self::merge_point(front, right, back, left))
             .collect()
     }


### PR DESCRIPTION
Latest version of rustfmt formats let..else statements, which were previously left as-is. This caused the CI build to fail on a couple of statements that were incorrectly formatted according to the new version. These were re-formatted.

Additionally, clippy lint useless_conversion started warning about unnecessary usage of .into_iter() in a few places. Those have been removed.

Finally, the Rust toolchain version in the CI workflow has been pinned to 1.72.0 to avoid similar build failures in the future. Rust version will have to be manually raised, including any changes to code required by that update.