### PR TITLE
Send shorter frames in configurator

### DIFF
--- a/configurator/src/capture.rs
+++ b/configurator/src/capture.rs
@@ -76,7 +76,7 @@ impl Capturer {
     }
 
     fn single_light_on(&self, index: usize) -> lightfx::Frame {
-        lightfx::Frame::new_black(self.number_of_lights).with_pixel(index, lightfx::Color::white())
+        lightfx::Frame::new_black(index + 1).with_pixel(index, lightfx::Color::white())
     }
 
     pub fn read_coordinates_from_file(


### PR DESCRIPTION
Since we turn off all the lights at the beginning of capturing the lights positions, we can shorten the sent frames to end with the single turned on light. This will half the amount of data send during capturing. 