### PR TITLE
visualizer: Fix camera controls in web contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,7 +2692,7 @@ dependencies = [
  "gloo-render",
  "gloo-storage",
  "gloo-timers",
- "gloo-utils 0.1.7",
+ "gloo-utils",
 ]
 
 [[package]]
@@ -2701,7 +2701,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
 dependencies = [
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -2749,28 +2749,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.1.7",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils 0.2.0",
- "http",
+ "gloo-utils",
  "js-sys",
  "pin-project",
  "serde",
@@ -2797,7 +2776,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
 dependencies = [
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "js-sys",
  "serde",
  "serde_json",
@@ -2821,19 +2800,6 @@ name = "gloo-utils"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
 dependencies = [
  "js-sys",
  "serde",
@@ -4907,13 +4873,11 @@ dependencies = [
  "bevy",
  "clap",
  "ewebsock",
- "gloo-net 0.5.0",
  "itertools 0.12.0",
  "reqwest",
  "serde",
  "serde_json",
  "url",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4943,8 +4907,8 @@ name = "rustmas-webui"
 version = "0.1.0"
 dependencies = [
  "animation-api 0.1.0",
- "gloo-net 0.2.6",
- "gloo-utils 0.1.7",
+ "gloo-net",
+ "gloo-utils",
  "instant",
  "lightfx 0.1.0",
  "log",
@@ -6693,7 +6657,7 @@ checksum = "2a1ccb53e57d3f7d847338cf5758befa811cabe207df07f543c06f502f9998cd"
 dependencies = [
  "console_error_panic_hook",
  "gloo",
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "indexmap 1.9.3",
  "js-sys",
  "scoped-tls-hkt",

--- a/visualizer/Cargo.toml
+++ b/visualizer/Cargo.toml
@@ -6,13 +6,11 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.11", features = ["derive"] }
 ewebsock = "0.4.0"
-gloo-net = "0.5.0"
 itertools = "0.12.0"
 reqwest = { version = "0.11.22", features = ["json", "blocking"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.108"
 url = "2.5.0"
-wasm-bindgen-futures = "0.4.39"
 
 [dependencies.bevy]
 version = "0.12.0"

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -8,19 +8,8 @@ You can run the visualizer as a native binary with:
 cargo run [--release] --bin rustmas-visualizer
 ```
 
-Alternatively, you can run it in the web browser. First you will have to
-install `wasm-server-runner`:
-
-```
-cargo install wasm-server-runner
-```
-
-and then you can start the visualizer with:
-
-```
-cd visualizer
-cargo run [--release] --target wasm32-unknown-unknown --bin rustmas-visualizer
-```
+If you would like to run the visualizer in a web browser, the suggested way
+is to [run is as a part of WebUI](../webapi/README.md#running-webui).
 
 Visualizer needs to be started after WebAPI.
 

--- a/visualizer/src/bin/visualizer.rs
+++ b/visualizer/src/bin/visualizer.rs
@@ -22,38 +22,24 @@ struct GetPointsResponse {
     points: Vec<(f32, f32, f32)>,
 }
 
-fn get_points_endpoint(endpoint: &Url) -> Url {
-    let mut endpoint = endpoint.clone();
-    endpoint.set_scheme("http").unwrap();
-    endpoint.join("points").unwrap()
+fn get_points(endpoint: &Url) -> Vec<(f32, f32, f32)> {
+    let endpoint = {
+        let mut endpoint = endpoint.clone();
+        endpoint.set_scheme("http").unwrap();
+        endpoint.join("points").unwrap()
+    };
+
+    reqwest::blocking::get(endpoint)
+        .unwrap()
+        .json::<GetPointsResponse>()
+        .unwrap()
+        .points
 }
 
 fn main() {
     let endpoint = Args::parse().endpoint;
     let frames_endpoint = get_frames_url(&endpoint);
-    let points_endpoint = get_points_endpoint(&endpoint);
+    let points = get_points(&endpoint);
 
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let points = reqwest::blocking::get(points_endpoint)
-            .unwrap()
-            .json::<GetPointsResponse>()
-            .unwrap()
-            .points;
-
-        rustmas_visualizer::run(frames_endpoint, points);
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_futures::spawn_local(async move {
-        let points = gloo_net::http::Request::get(points_endpoint.as_str())
-            .send()
-            .await
-            .unwrap()
-            .json::<GetPointsResponse>()
-            .await
-            .unwrap()
-            .points;
-        rustmas_visualizer::run(frames_endpoint, points);
-    });
+    rustmas_visualizer::run(frames_endpoint, points);
 }

--- a/webui/src/visualizer.rs
+++ b/webui/src/visualizer.rs
@@ -1,4 +1,5 @@
 use log::error;
+use web_sys::MouseEvent;
 use yew::{html, prelude::Html, Callback, Component, Context};
 
 use crate::api;
@@ -53,7 +54,14 @@ impl Component for Visualizer {
     fn view(&self, _ctx: &Context<Self>) -> Html {
         html! {
             <section class="visualizer-container">
-                <canvas id="visualizer"></canvas>
+                <canvas id="visualizer"
+                    oncontextmenu={Callback::from(|e: MouseEvent| e.prevent_default())}
+                    onmousedown={Callback::from(|e: MouseEvent| {
+                        if e.button() == 1 {
+                            e.prevent_default();
+                        }
+                    })}
+                ></canvas>
             </section>
         }
     }


### PR DESCRIPTION
fixes #207

I have also removed the support for running the visualizer standalone in web browser. This is because there is no way to fix the camera controls within bevy (it has no notion of `oncontextmenu` event, and no way to prevent default on those), and there is no reason to keep supporting it, since you can now run visualizer in WebUI, and for any manual testing you'd need to run the WebUI anyway. 