### PR TITLE
Remove animation_name method from Animation trait

### DIFF
--- a/animation-api/src/api.rs
+++ b/animation-api/src/api.rs
@@ -13,8 +13,6 @@ pub struct AnimationError {
 pub trait Animation {
     type Parameters: GetSchema + DeserializeOwned + Serialize + Default + Clone;
 
-    fn animation_name(&self) -> &str;
-
     fn get_schema(&self) -> ConfigurationSchema
     where
         Self::Parameters: GetSchema,
@@ -48,7 +46,6 @@ pub enum JsonRpcMethod {
     Initialize {
         points: Vec<(f64, f64, f64)>,
     },
-    AnimationName,
     ParameterSchema,
     SetParameters {
         params: HashMap<String, ParameterValue>,

--- a/animation-plugin-macro/src/lib.rs
+++ b/animation-plugin-macro/src/lib.rs
@@ -75,11 +75,6 @@ pub fn plugin(_attr: TokenStream, item: TokenStream) -> TokenStream {
                             animation = Some(<#name>::create(points));
                             respond(message.id, ());
                         }
-                        JsonRpcMethod::AnimationName => {
-                            if let Some(animation) = animation.as_ref() {
-                                respond(message.id, animation.animation_name());
-                            }
-                        },
                         JsonRpcMethod::ParameterSchema => {
                             if let Some(animation) = animation.as_ref() {
                                 respond(message.id, animation.get_schema());

--- a/animation-utils/src/decorators/brightness_controlled.rs
+++ b/animation-utils/src/decorators/brightness_controlled.rs
@@ -51,10 +51,6 @@ where
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        self.animation.animation_name()
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.animation.set_parameters(parameters.inner.clone());
         self.parameters = parameters;

--- a/animation-utils/src/decorators/off_switch.rs
+++ b/animation-utils/src/decorators/off_switch.rs
@@ -92,10 +92,6 @@ where
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        self.animation.animation_name()
-    }
-
     fn get_schema(&self) -> ConfigurationSchema {
         Self::Parameters::schema()
     }

--- a/animation-utils/src/decorators/speed_controlled.rs
+++ b/animation-utils/src/decorators/speed_controlled.rs
@@ -48,10 +48,6 @@ where
         self.animation.render()
     }
 
-    fn animation_name(&self) -> &str {
-        self.animation.animation_name()
-    }
-
     fn get_schema(&self) -> ConfigurationSchema {
         Self::Parameters::schema()
     }

--- a/animations/src/bin/audio_boom.rs
+++ b/animations/src/bin/audio_boom.rs
@@ -119,10 +119,6 @@ impl Animation for AudioVisualizer {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Audio Boom"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/audio_visualizer.rs
+++ b/animations/src/bin/audio_visualizer.rs
@@ -103,10 +103,6 @@ impl Animation for AudioVisualizer {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Audio Visualizer"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/audio_wave.rs
+++ b/animations/src/bin/audio_wave.rs
@@ -135,10 +135,6 @@ impl Animation for AudioVisualizer {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Audio Wave"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/barber_pole.rs
+++ b/animations/src/bin/barber_pole.rs
@@ -85,10 +85,6 @@ impl Animation for BarberPole {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Barber Pole"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/beats.rs
+++ b/animations/src/bin/beats.rs
@@ -110,10 +110,6 @@ impl Animation for CircleBoom {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Circle boom"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/check.rs
+++ b/animations/src/bin/check.rs
@@ -30,10 +30,6 @@ impl Animation for Check {
         lightfx::Frame::new_black(self.points_count).with_pixel(index, lightfx::Color::white())
     }
 
-    fn animation_name(&self) -> &str {
-        "Testing: Check Lights"
-    }
-
     fn get_fps(&self) -> f64 {
         8.0
     }

--- a/animations/src/bin/circle_boom.rs
+++ b/animations/src/bin/circle_boom.rs
@@ -83,10 +83,6 @@ impl Animation for CircleBoom {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Circle boom"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/circle_grid.rs
+++ b/animations/src/bin/circle_grid.rs
@@ -125,10 +125,6 @@ impl Animation for CircleGrid {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Circle grid"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/circle_wave.rs
+++ b/animations/src/bin/circle_wave.rs
@@ -99,10 +99,6 @@ impl Animation for CircleWave {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Circle Wave"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         if parameters.state == Switch::Off {
             self.off_after = Some(self.time.ceil() - 0.25);

--- a/animations/src/bin/classic.rs
+++ b/animations/src/bin/classic.rs
@@ -103,10 +103,6 @@ impl Animation for Classic {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Classic"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/color_picker.rs
+++ b/animations/src/bin/color_picker.rs
@@ -34,10 +34,6 @@ impl Animation for ColorPicker {
         lightfx::Frame::new(self.points_count, self.parameters.color)
     }
 
-    fn animation_name(&self) -> &str {
-        "Testing: Color picker"
-    }
-
     fn get_fps(&self) -> f64 {
         0.0
     }

--- a/animations/src/bin/detection_status.rs
+++ b/animations/src/bin/detection_status.rs
@@ -39,10 +39,6 @@ impl Animation for DetectionStatus {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Testing: Detection Status"
-    }
-
     fn get_fps(&self) -> f64 {
         0.0
     }

--- a/animations/src/bin/doom_fire.rs
+++ b/animations/src/bin/doom_fire.rs
@@ -162,10 +162,6 @@ impl Animation for DoomFireAnimation {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Doom fire"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/event_test.rs
+++ b/animations/src/bin/event_test.rs
@@ -51,10 +51,6 @@ impl Animation for EventTest {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Event test"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/heartbeat.rs
+++ b/animations/src/bin/heartbeat.rs
@@ -98,10 +98,6 @@ impl Animation for HeartBoom {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Heartbeat"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         if parameters.state == Switch::Off {
             self.off_after = Some(self.time.ceil());

--- a/animations/src/bin/indexing.rs
+++ b/animations/src/bin/indexing.rs
@@ -61,10 +61,6 @@ impl Animation for Indexing {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Testing: Indexing"
-    }
-
     fn get_fps(&self) -> f64 {
         0.0
     }

--- a/animations/src/bin/lightspeed.rs
+++ b/animations/src/bin/lightspeed.rs
@@ -169,10 +169,6 @@ impl Animation for Lightspeed {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Lightspeed"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/manual_sweep.rs
+++ b/animations/src/bin/manual_sweep.rs
@@ -128,10 +128,6 @@ impl Animation for ManualSweep {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Testing: Manual sweep"
-    }
-
     fn get_fps(&self) -> f64 {
         0.0
     }

--- a/animations/src/bin/midi_wave.rs
+++ b/animations/src/bin/midi_wave.rs
@@ -108,10 +108,6 @@ impl Animation for MidiWaveAnimation {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "MIDI Wave"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/moon.rs
+++ b/animations/src/bin/moon.rs
@@ -105,10 +105,6 @@ impl Animation for Moon {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Moon"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.noise.set_frequency(parameters.noise_frequency as f32);
         self.parameters = parameters;

--- a/animations/src/bin/particle_fire.rs
+++ b/animations/src/bin/particle_fire.rs
@@ -232,10 +232,6 @@ impl Animation for DoomFireAnimation {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Particle fire"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/pillars.rs
+++ b/animations/src/bin/pillars.rs
@@ -217,10 +217,6 @@ impl Animation for Pillars {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Random pillar"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/present.rs
+++ b/animations/src/bin/present.rs
@@ -89,10 +89,6 @@ impl Animation for Present {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Present"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/rainbow_cable.rs
+++ b/animations/src/bin/rainbow_cable.rs
@@ -52,10 +52,6 @@ impl Animation for RainbowCable {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Cable"
-    }
-
     fn get_parameters(&self) -> Self::Parameters {
         self.parameters.clone()
     }

--- a/animations/src/bin/rainbow_cylinder.rs
+++ b/animations/src/bin/rainbow_cylinder.rs
@@ -57,10 +57,6 @@ impl Animation for RainbowCylinder {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Cylinder"
-    }
-
     fn get_parameters(&self) -> Self::Parameters {
         self.parameters.clone()
     }

--- a/animations/src/bin/rainbow_halves.rs
+++ b/animations/src/bin/rainbow_halves.rs
@@ -75,10 +75,6 @@ impl Animation for RainbowHalves {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Halves"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/rainbow_sphere.rs
+++ b/animations/src/bin/rainbow_sphere.rs
@@ -69,10 +69,6 @@ impl Animation for RainbowSphere {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Sphere"
-    }
-
     fn set_parameters(&mut self, parameters: Parameters) {
         self.parameters = parameters;
         self.reset();

--- a/animations/src/bin/rainbow_spiral.rs
+++ b/animations/src/bin/rainbow_spiral.rs
@@ -55,10 +55,6 @@ impl Animation for RainbowSpiral {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Spiral"
-    }
-
     fn get_parameters(&self) -> Self::Parameters {
         self.parameters.clone()
     }

--- a/animations/src/bin/rainbow_waterfall.rs
+++ b/animations/src/bin/rainbow_waterfall.rs
@@ -50,10 +50,6 @@ impl Animation for RainbowWaterfall {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Rainbow Waterfall"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/random_sweep.rs
+++ b/animations/src/bin/random_sweep.rs
@@ -119,10 +119,6 @@ impl Animation for RandomSweep {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Random Sweep"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/single_color.rs
+++ b/animations/src/bin/single_color.rs
@@ -42,10 +42,6 @@ impl Animation for SingleColor {
         lightfx::Frame::new(self.points_count, self.parameters.color)
     }
 
-    fn animation_name(&self) -> &str {
-        "Single Color"
-    }
-
     fn get_fps(&self) -> f64 {
         30.0
     }

--- a/animations/src/bin/snow.rs
+++ b/animations/src/bin/snow.rs
@@ -91,10 +91,6 @@ impl Animation for Snow {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Snow"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
         self.centers

--- a/animations/src/bin/spinning_halves.rs
+++ b/animations/src/bin/spinning_halves.rs
@@ -89,10 +89,6 @@ impl Animation for SpinningHalves {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Spinning Halves"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/stars.rs
+++ b/animations/src/bin/stars.rs
@@ -97,10 +97,6 @@ impl Animation for Stars {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Stars"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
         self.stars

--- a/animations/src/bin/sweep.rs
+++ b/animations/src/bin/sweep.rs
@@ -99,10 +99,6 @@ impl Animation for Sweep {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Sweep"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animations/src/bin/waterfall.rs
+++ b/animations/src/bin/waterfall.rs
@@ -70,10 +70,6 @@ impl Animation for RainbowWaterfall {
             .into()
     }
 
-    fn animation_name(&self) -> &str {
-        "Waterfall"
-    }
-
     fn set_parameters(&mut self, parameters: Self::Parameters) {
         self.parameters = parameters;
     }

--- a/animator/src/jsonrpc.rs
+++ b/animator/src/jsonrpc.rs
@@ -168,14 +168,6 @@ impl Plugin for JsonRpcPlugin {
         }
     }
 
-    fn animation_name(&self) -> Result<String, AnimationPluginError> {
-        match self.endpoint.send_message(JsonRpcMethod::AnimationName) {
-            Ok(JsonRpcResult::Result(name)) => Ok(name),
-            Ok(JsonRpcResult::Error(e)) => Err(AnimationPluginError::AnimationError(e.data)),
-            Err(e) => Err(AnimationPluginError::CommunicationError(Box::new(e))),
-        }
-    }
-
     fn get_schema(&self) -> Result<ConfigurationSchema, AnimationPluginError> {
         match self.endpoint.send_message(JsonRpcMethod::ParameterSchema) {
             Ok(JsonRpcResult::Result(schema)) => Ok(schema),

--- a/animator/src/plugin.rs
+++ b/animator/src/plugin.rs
@@ -110,7 +110,6 @@ pub trait Plugin {
     fn configuration(&self) -> Result<Configuration, AnimationPluginError>;
     fn update(&mut self, time_delta: f64) -> Result<(), AnimationPluginError>;
     fn render(&self) -> Result<lightfx::Frame, AnimationPluginError>;
-    fn animation_name(&self) -> Result<String, AnimationPluginError>;
     fn get_schema(&self) -> Result<ConfigurationSchema, AnimationPluginError>;
     fn set_parameters(
         &mut self,


### PR DESCRIPTION
Animation's display name is now provided via the manifest, so this method was unused and clippy started complaining.